### PR TITLE
Add 3D crease between screen and buttons for realistic look

### DIFF
--- a/src/components/Calculators/BasicCalculator.tsx
+++ b/src/components/Calculators/BasicCalculator.tsx
@@ -192,6 +192,7 @@ const BasicCalculator = () => {
                 </span>
             </div>
             </div>
+            <div className="crease"></div>
             <div className="basic-keys-container">
                 <div className="top row">
                     <button onClick={setFunction} value="invert" className="operator-key divide">+/-</button>

--- a/src/styles/calculator.scss
+++ b/src/styles/calculator.scss
@@ -164,11 +164,17 @@ button:focus {
 .basic > .crease {
     width: 100%;
     height: 12px;
-    background-color: $primary-bland;
+    background: linear-gradient(
+        to bottom,
+        $primary-bland 0%,
+        darken($primary-bland, 6%) 30%,
+        darken($primary-bland, 8%) 50%,
+        darken($primary-bland, 6%) 70%,
+        $primary-bland 100%
+    );
     box-shadow:
-        inset 0 4px 6px rgba(0, 0, 0, 0.3),
-        inset 0 -3px 5px rgba(255, 255, 255, 0.15),
-        inset 0 1px 2px rgba(0, 0, 0, 0.15);
+        inset 0 4px 6px rgba(0, 0, 0, 0.2),
+        inset 0 -3px 5px rgba(255, 255, 255, 0.1);
 }
 
 .basic > .basic-keys-container {
@@ -379,68 +385,43 @@ button:focus {
 }
 
 // Worn text effect for heavily used buttons
-// The center of the text fades as if the print has rubbed off
+// Overlays a gradient that masks the center of the text to look faded
 
-@mixin worn-text-heavy {
-    $faded: rgba(red($super_white), green($super_white), blue($super_white), 0.35);
-    $faded-mid: rgba(red($super_white), green($super_white), blue($super_white), 0.25);
-    background: linear-gradient(
-        to bottom,
-        $super_white 0%,
-        $faded 40%,
-        $faded-mid 60%,
-        $super_white 100%
-    );
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
-}
+@mixin worn-overlay($opacity) {
+    position: relative;
+    overflow: hidden;
 
-@mixin worn-text-medium {
-    $faded: rgba(red($super_white), green($super_white), blue($super_white), 0.5);
-    $faded-mid: rgba(red($super_white), green($super_white), blue($super_white), 0.45);
-    background: linear-gradient(
-        to bottom,
-        $super_white 0%,
-        $faded 45%,
-        $faded-mid 55%,
-        $super_white 100%
-    );
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
-}
-
-@mixin worn-text-light {
-    $faded: rgba(red($super_white), green($super_white), blue($super_white), 0.65);
-    $faded-mid: rgba(red($super_white), green($super_white), blue($super_white), 0.6);
-    background: linear-gradient(
-        to bottom,
-        $super_white 0%,
-        $faded 45%,
-        $faded-mid 55%,
-        $super_white 100%
-    );
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
+    &::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: radial-gradient(
+            ellipse at center,
+            $primary_black $opacity,
+            transparent 70%
+        );
+        pointer-events: none;
+    }
 }
 
 // Heavy wear - most used buttons
 .basic-key.clear,
 .basic-key.zero {
-    @include worn-text-heavy;
+    @include worn-overlay(35%);
 }
 
 // Medium wear
 .basic-key.one,
 .operator-key.plus {
-    @include worn-text-medium;
+    @include worn-overlay(25%);
 }
 
 // Light wear
 .basic-key.\35,
 .basic-key.two,
 .operator-key.divide {
-    @include worn-text-light;
+    @include worn-overlay(15%);
 }

--- a/src/styles/calculator.scss
+++ b/src/styles/calculator.scss
@@ -159,11 +159,12 @@ button:focus {
 
 .basic > .crease {
     width: 100%;
-    height: 8px;
+    height: 12px;
     background-color: $primary-bland;
     box-shadow:
-        inset 0 3px 4px rgba(0, 0, 0, 0.25),
-        inset 0 -2px 3px rgba(255, 255, 255, 0.15);
+        inset 0 4px 6px rgba(0, 0, 0, 0.3),
+        inset 0 -3px 5px rgba(255, 255, 255, 0.15),
+        inset 0 1px 2px rgba(0, 0, 0, 0.15);
 }
 
 .basic > .basic-keys-container {

--- a/src/styles/calculator.scss
+++ b/src/styles/calculator.scss
@@ -21,6 +21,10 @@ button:focus {
     align-items: center;
     -webkit-box-shadow: 5px 5px 10px 0px rgba(0, 0, 0, 0.62);
     box-shadow: 5px 5px 10px 0px rgba(0, 0, 0, 0.62);
+    background-image:
+        radial-gradient(ellipse at 15% 10%, rgba(0, 0, 0, 0.03) 0%, transparent 50%),
+        radial-gradient(ellipse at 85% 95%, rgba(0, 0, 0, 0.04) 0%, transparent 40%),
+        radial-gradient(ellipse at 50% 50%, rgba(0, 0, 0, 0.02) 0%, transparent 70%);
 
     @media screen and (max-width: 416px) {
         width: 100%;
@@ -372,4 +376,71 @@ button:focus {
 
 .red {
     background-color: $primary-power-red;
+}
+
+// Worn text effect for heavily used buttons
+// The center of the text fades as if the print has rubbed off
+
+@mixin worn-text-heavy {
+    $faded: rgba(red($super_white), green($super_white), blue($super_white), 0.35);
+    $faded-mid: rgba(red($super_white), green($super_white), blue($super_white), 0.25);
+    background: linear-gradient(
+        to bottom,
+        $super_white 0%,
+        $faded 40%,
+        $faded-mid 60%,
+        $super_white 100%
+    );
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+@mixin worn-text-medium {
+    $faded: rgba(red($super_white), green($super_white), blue($super_white), 0.5);
+    $faded-mid: rgba(red($super_white), green($super_white), blue($super_white), 0.45);
+    background: linear-gradient(
+        to bottom,
+        $super_white 0%,
+        $faded 45%,
+        $faded-mid 55%,
+        $super_white 100%
+    );
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+@mixin worn-text-light {
+    $faded: rgba(red($super_white), green($super_white), blue($super_white), 0.65);
+    $faded-mid: rgba(red($super_white), green($super_white), blue($super_white), 0.6);
+    background: linear-gradient(
+        to bottom,
+        $super_white 0%,
+        $faded 45%,
+        $faded-mid 55%,
+        $super_white 100%
+    );
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+// Heavy wear - most used buttons
+.basic-key.clear,
+.basic-key.zero {
+    @include worn-text-heavy;
+}
+
+// Medium wear
+.basic-key.one,
+.operator-key.plus {
+    @include worn-text-medium;
+}
+
+// Light wear
+.basic-key.\35,
+.basic-key.two,
+.operator-key.divide {
+    @include worn-text-light;
 }

--- a/src/styles/calculator.scss
+++ b/src/styles/calculator.scss
@@ -159,11 +159,11 @@ button:focus {
 
 .basic > .crease {
     width: 100%;
-    height: 4px;
+    height: 8px;
     background-color: $primary-bland;
     box-shadow:
-        inset 0 2px 3px rgba(0, 0, 0, 0.3),
-        inset 0 -1px 2px rgba(255, 255, 255, 0.2);
+        inset 0 3px 4px rgba(0, 0, 0, 0.25),
+        inset 0 -2px 3px rgba(255, 255, 255, 0.15);
 }
 
 .basic > .basic-keys-container {

--- a/src/styles/calculator.scss
+++ b/src/styles/calculator.scss
@@ -163,10 +163,10 @@ button:focus {
     position: relative;
     background: linear-gradient(
         to bottom,
-        darken($primary-bland, 12%) 0%,
-        darken($primary-bland, 18%) 40%,
-        darken($primary-bland, 8%) 60%,
-        $primary-bland 100%
+        rgba(0, 0, 0, 0.15) 0%,
+        rgba(0, 0, 0, 0.25) 40%,
+        rgba(0, 0, 0, 0.10) 60%,
+        rgba(255, 255, 255, 0.05) 100%
     );
     box-shadow:
         inset 0 1px 3px rgba(0, 0, 0, 0.35),
@@ -180,7 +180,7 @@ button:focus {
         left: 0;
         right: 0;
         height: 1px;
-        background: rgba(0, 0, 0, 0.2);
+        background: rgba(0, 0, 0, 0.25);
     }
 
     &::after {
@@ -190,7 +190,7 @@ button:focus {
         left: 0;
         right: 0;
         height: 1px;
-        background: rgba(255, 255, 255, 0.3);
+        background: rgba(255, 255, 255, 0.2);
     }
 }
 
@@ -209,6 +209,14 @@ button:focus {
     > button {
         border-radius: 4px;
         height: 65%;
+
+        &:hover {
+            filter: brightness(1.1);
+        }
+
+        &:active {
+            filter: brightness(0.95);
+        }
     }
 }
 
@@ -221,6 +229,26 @@ button:focus {
     > button {
         flex: 1;
         margin: 4px;
+        box-shadow:
+            0 3px 1px rgba(0, 0, 0, 0.4),
+            0 4px 6px rgba(0, 0, 0, 0.2),
+            inset 0 1px 0 rgba(255, 255, 255, 0.15);
+        transition: box-shadow 0.1s ease, transform 0.1s ease;
+
+        &:hover {
+            box-shadow:
+                0 3px 1px rgba(0, 0, 0, 0.45),
+                0 5px 8px rgba(0, 0, 0, 0.25),
+                inset 0 1px 0 rgba(255, 255, 255, 0.2);
+        }
+
+        &:active {
+            transform: translateY(2px);
+            box-shadow:
+                0 1px 1px rgba(0, 0, 0, 0.4),
+                0 1px 2px rgba(0, 0, 0, 0.2),
+                inset 0 1px 3px rgba(0, 0, 0, 0.15);
+        }
     }
 }
 
@@ -258,6 +286,27 @@ button:focus {
     transform: skewX(-4deg);
     font-size: 42px;
     flex: 1;
+    box-shadow:
+        0 3px 1px rgba(0, 0, 0, 0.4),
+        0 4px 6px rgba(0, 0, 0, 0.2),
+        inset 0 1px 0 rgba(255, 255, 255, 0.15);
+    transition: box-shadow 0.1s ease, transform 0.1s ease;
+
+    &:hover {
+        box-shadow:
+            0 3px 1px rgba(0, 0, 0, 0.45),
+            0 5px 8px rgba(0, 0, 0, 0.25),
+            inset 0 1px 0 rgba(255, 255, 255, 0.2);
+        brightness: 1.05;
+    }
+
+    &:active {
+        transform: skewX(-4deg) translateY(2px);
+        box-shadow:
+            0 1px 1px rgba(0, 0, 0, 0.4),
+            0 1px 2px rgba(0, 0, 0, 0.2),
+            inset 0 1px 3px rgba(0, 0, 0, 0.15);
+    }
 }
 
 .basic-arithmetic {
@@ -300,6 +349,26 @@ button:focus {
     > button {
         flex: 0.208;
         margin: 4px;
+        box-shadow:
+            0 3px 1px rgba(0, 0, 0, 0.4),
+            0 4px 6px rgba(0, 0, 0, 0.2),
+            inset 0 1px 0 rgba(255, 255, 255, 0.15);
+        transition: box-shadow 0.1s ease, transform 0.1s ease;
+
+        &:hover {
+            box-shadow:
+                0 3px 1px rgba(0, 0, 0, 0.45),
+                0 5px 8px rgba(0, 0, 0, 0.25),
+                inset 0 1px 0 rgba(255, 255, 255, 0.2);
+        }
+
+        &:active {
+            transform: translateY(2px);
+            box-shadow:
+                0 1px 1px rgba(0, 0, 0, 0.4),
+                0 1px 2px rgba(0, 0, 0, 0.2),
+                inset 0 1px 3px rgba(0, 0, 0, 0.15);
+        }
 
         @media screen and (max-width: 412px) {
             flex: 0.225;

--- a/src/styles/calculator.scss
+++ b/src/styles/calculator.scss
@@ -159,39 +159,11 @@ button:focus {
 
 .basic > .crease {
     width: 100%;
-    height: 6px;
-    position: relative;
-    background: linear-gradient(
-        to bottom,
-        rgba(0, 0, 0, 0.15) 0%,
-        rgba(0, 0, 0, 0.25) 40%,
-        rgba(0, 0, 0, 0.10) 60%,
-        rgba(255, 255, 255, 0.05) 100%
-    );
+    height: 4px;
+    background-color: $primary-bland;
     box-shadow:
-        inset 0 1px 3px rgba(0, 0, 0, 0.35),
-        inset 0 -1px 2px rgba(255, 255, 255, 0.25),
-        0 2px 4px rgba(0, 0, 0, 0.15);
-
-    &::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 1px;
-        background: rgba(0, 0, 0, 0.25);
-    }
-
-    &::after {
-        content: '';
-        position: absolute;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        height: 1px;
-        background: rgba(255, 255, 255, 0.2);
-    }
+        inset 0 2px 3px rgba(0, 0, 0, 0.3),
+        inset 0 -1px 2px rgba(255, 255, 255, 0.2);
 }
 
 .basic > .basic-keys-container {

--- a/src/styles/calculator.scss
+++ b/src/styles/calculator.scss
@@ -84,10 +84,14 @@ button:focus {
     > p {
         font-size: 32px;
         font-weight: bold;
+        text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15);
     }
 
     > h4 {
         margin-top: -8px;
+        letter-spacing: 2px;
+        font-size: 11px;
+        color: darken($primary-bland, 40%);
     }
 }
 
@@ -133,8 +137,12 @@ button:focus {
     padding: 8px;
     height: 60px;
     border-radius: 4px;
-    background: gray;
+    background: linear-gradient(to bottom, #a8b0a0, #b8c0b0 30%, #c0c8b8 70%, #a8b0a0);
     border: 1px solid $primary_black;
+    box-shadow:
+        inset 0 2px 6px rgba(0, 0, 0, 0.4),
+        inset 0 -1px 2px rgba(0, 0, 0, 0.15),
+        0 1px 0 rgba(255, 255, 255, 0.2);
     display: flex;
     align-items: flex-end;
     justify-content: flex-end;
@@ -147,6 +155,43 @@ button:focus {
     flex: 0.2;
     width: 100%;
     background-color: $primary-bland;
+}
+
+.basic > .crease {
+    width: 100%;
+    height: 6px;
+    position: relative;
+    background: linear-gradient(
+        to bottom,
+        darken($primary-bland, 12%) 0%,
+        darken($primary-bland, 18%) 40%,
+        darken($primary-bland, 8%) 60%,
+        $primary-bland 100%
+    );
+    box-shadow:
+        inset 0 1px 3px rgba(0, 0, 0, 0.35),
+        inset 0 -1px 2px rgba(255, 255, 255, 0.25),
+        0 2px 4px rgba(0, 0, 0, 0.15);
+
+    &::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: 1px;
+        background: rgba(0, 0, 0, 0.2);
+    }
+
+    &::after {
+        content: '';
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: 1px;
+        background: rgba(255, 255, 255, 0.3);
+    }
 }
 
 .basic > .basic-keys-container {


### PR DESCRIPTION
- Add crease divider element between screen-container and keys with
  gradient, inset shadows, and highlight/shadow edge lines for depth
- Enhance LCD screen with greenish gradient and inset shadow to mimic
  a real calculator display
- Add subtle text-shadow on logo and style the model number (7000)
  with letter-spacing and muted color

https://claude.ai/code/session_018YY3VUuyZabdjgoiyzGu7Y